### PR TITLE
Enables debugger when running cargo

### DIFF
--- a/company-intranet/pom.xml
+++ b/company-intranet/pom.xml
@@ -150,7 +150,7 @@
             <plugin>
                 <groupId>org.codehaus.cargo</groupId>
                 <artifactId>cargo-maven2-plugin</artifactId>
-                <version>1.4.14</version>
+                <version>1.6.2</version>
                 <configuration>
                     <container>
                         <containerId>tomcat8x</containerId>
@@ -182,6 +182,12 @@
                     <configuration>
                         <properties>
                             <cargo.servlet.port>${tomcat.port}</cargo.servlet.port>
+                            <cargo.start.jvmargs>
+                              -Xdebug
+                              -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005
+                              -Xnoagent
+                              -Djava.compiler=NONE
+                            </cargo.start.jvmargs>
                         </properties>
                         <configfiles>
                             <configfile>

--- a/hello-styleguide/pom.xml
+++ b/hello-styleguide/pom.xml
@@ -150,7 +150,7 @@
             <plugin>
                 <groupId>org.codehaus.cargo</groupId>
                 <artifactId>cargo-maven2-plugin</artifactId>
-                <version>1.4.14</version>
+                <version>1.6.2</version>
                 <configuration>
                     <container>
                         <containerId>tomcat8x</containerId>
@@ -182,6 +182,12 @@
                     <configuration>
                         <properties>
                             <cargo.servlet.port>${tomcat.port}</cargo.servlet.port>
+                            <cargo.start.jvmargs>
+                              -Xdebug
+                              -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005
+                              -Xnoagent
+                              -Djava.compiler=NONE
+                            </cargo.start.jvmargs>
                         </properties>
                         <configfiles>
                             <configfile>

--- a/hello-world/pom.xml
+++ b/hello-world/pom.xml
@@ -155,7 +155,7 @@
             <plugin>
                 <groupId>org.codehaus.cargo</groupId>
                 <artifactId>cargo-maven2-plugin</artifactId>
-                <version>1.4.14</version>
+                <version>1.6.2</version>
                 <configuration>
                     <container>
                         <containerId>tomcat8x</containerId>
@@ -187,6 +187,12 @@
                     <configuration>
                         <properties>
                             <cargo.servlet.port>${tomcat.port}</cargo.servlet.port>
+                            <cargo.start.jvmargs>
+                              -Xdebug
+                              -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005
+                              -Xnoagent
+                              -Djava.compiler=NONE
+                            </cargo.start.jvmargs>
                         </properties>
                         <configfiles>
                             <configfile>

--- a/init/pom.xml
+++ b/init/pom.xml
@@ -150,7 +150,7 @@
             <plugin>
                 <groupId>org.codehaus.cargo</groupId>
                 <artifactId>cargo-maven2-plugin</artifactId>
-                <version>1.4.14</version>
+                <version>1.6.2</version>
                 <configuration>
                     <container>
                         <containerId>tomcat8x</containerId>
@@ -182,6 +182,12 @@
                     <configuration>
                         <properties>
                             <cargo.servlet.port>${tomcat.port}</cargo.servlet.port>
+                            <cargo.start.jvmargs>
+                              -Xdebug
+                              -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005
+                              -Xnoagent
+                              -Djava.compiler=NONE
+                            </cargo.start.jvmargs>
                         </properties>
                         <configfiles>
                             <configfile>


### PR DESCRIPTION
Debugger can be run using the following settings:

![image](https://user-images.githubusercontent.com/1299507/31022935-5fdff610-a508-11e7-9e1c-d6755038fb3a.png)
